### PR TITLE
Build bootstrap css

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import os
+import re
 from subprocess import call
 
 from flask.ext.script import Manager, Command
@@ -16,6 +18,39 @@ def build_js():
         'node_modules/webpack/bin/webpack.js',
         './webpack.config.js'
     ])
+
+@manager.command
+def build_external_css():
+    """Configures and builds external CSS libraries"""
+    
+    # Symbolically link bootstrap font files
+    extensions = ['eot', 'svg', 'ttf', 'woff', 'woff2']
+    if not os.path.exists('ocfnet/static/fonts/bootstrap'):
+        os.makedirs('ocfnet/static/fonts/bootstrap')
+    root = os.path.dirname(os.path.abspath(__file__))
+    filename = 'glyphicons-halflings-regular'
+    for ext in extensions:
+        src = '%s/node_modules/bootstrap/dist/fonts/%s.%s' % \
+            (root, filename, ext)
+        dest = 'ocfnet/static/fonts/bootstrap/%s.%s' % (filename, ext)
+        if not os.path.lexists(dest):
+            os.symlink(src, dest)
+
+    # Replace font path less variable
+    with file('node_modules/bootstrap/less/variables.less') as r:
+        variables = r.read()
+        r.close()
+        variables = re.sub(r'@icon-font-path:.*', 
+                           '@icon-font-path: "/static/fonts/bootstrap/";', 
+                           variables)
+        with file('node_modules/bootstrap/less/variables.less', 'w') as w:
+            w.write(variables)
+            w.close()
+
+    # Build bootstrap CSS
+    os.chdir('node_modules/bootstrap')
+    call(['npm', 'install'])
+    call(['node', '../../node_modules/grunt-cli/bin/grunt', 'dist'])
 
 if __name__ == '__main__':
     manager.run()

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-loader": "^5.3.2",
     "bootstrap": "^3.3.5",
     "events": "^1.0.2",
+    "grunt-cli": "^0.1.13",
     "react": "^0.13.3",
     "react-bootstrap": "^0.24.5",
     "react-router": "^0.13.3",


### PR DESCRIPTION
Adds a manage command to build the external bootstrap CSS.

```
$ ./manage.py build_external_css
```
